### PR TITLE
Fixes markdown syntax for links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # preact-digital-rain-hn
 > HN Demo app renders 2D canvas in web worker - https://digital-rain-hn.zouhir.codes
 
-
 ## About
 This is a personal experiment to render canvas animation off the main thread using Web Workers and `transferControlToOffscreen`
 
-This spec is fairly new and not widely supported yet, more info on (MDN)[https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen]
+This spec is fairly new and not widely supported yet, more info on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/transferControlToOffscreen)
 
 ## Tech Stack & Credits
-- This app uses ⚛️ Preact via (preact-cli)[https://github.com/developit/preact-cli]
-- (HN API)[https://hacker-news.firebaseio.com] hosted on firebase by some awesome person
+- This app uses ⚛️ Preact via [preact-cli](https://github.com/developit/preact-cli)
+- [HN API](https://hacker-news.firebaseio.com) hosted on firebase by some awesome person
 - Inspired by a conversation with my awesome work colleague Bo Cupp
 - Canvas animation is from this [Codepen](https://codepen.io/P3R0/pen/MwgoKv) by Ebram Marzouk.


### PR DESCRIPTION
You mixed up the markdown syntax for a few links, I **always** make the same mistake too 😅 

`README.md` renders correctly for me on this branch using the [Markdown Preview Github Styling](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-preview-github-styles) VS Code extension.

<img width="924" alt="screen shot 2018-11-15 at 6 36 16 pm" src="https://user-images.githubusercontent.com/1559669/48537460-c7250300-e905-11e8-8d1b-0dabd62df69b.png">
